### PR TITLE
Walking sprite improvements

### DIFF
--- a/app/walking_sprite_example.rb
+++ b/app/walking_sprite_example.rb
@@ -28,8 +28,14 @@ class WalkingSpriteExample < MG::Scene
     add @hero
 
     on_touch_begin do |event|
-      @hero.flipped_horizontally = moved_left?(event.location)
-      @hero.move_to(event.location, 1)
+      new_location = event.location
+      distance = Math.sqrt( # Pythagorean theorem
+        ((@hero.position.x - new_location.x).abs ** 2) +
+        ((@hero.position.y - new_location.y).abs ** 2)
+      )
+      speed = distance / 150 # move at a rate of 150 points per second
+      @hero.flipped_horizontally = moved_left?(new_location)
+      @hero.move_to(event.location, speed)
     end
   end
 

--- a/app/walking_sprite_example.rb
+++ b/app/walking_sprite_example.rb
@@ -22,12 +22,11 @@ class WalkingSpriteExample < MG::Scene
 
     @hero = MG::Sprite.new("hero.png")
     @hero.position = [screen_width / 2, screen_height / 2]
-    frames = [1, 2, 3, 4, 3, 2].map {|i| "hero_walk#{i}.png"}
-    @hero.animate(frames, 0.15, :forever)
     @hero.scale = 2
     add @hero
 
     on_touch_begin do |event|
+      @hero.stop_all_actions # cancel any moves in progress since our destination has changed
       new_location = event.location
       distance = Math.sqrt( # Pythagorean theorem
         ((@hero.position.x - new_location.x).abs ** 2) +
@@ -36,6 +35,13 @@ class WalkingSpriteExample < MG::Scene
       speed = distance / 150 # move at a rate of 150 points per second
       @hero.flipped_horizontally = moved_left?(new_location)
       @hero.move_to(event.location, speed)
+      frames = [1, 2, 3, 4, 3, 2].map {|i| "hero_walk#{i}.png"}
+      @hero.animate(frames, 0.15, :forever)
+      # FIXME: use a Sequence instead of a DelayTime action
+      @hero.run_action(MG::DelayTime.new(speed)) do
+        @hero.stop_all_actions # stop walking animation
+        @hero.animate(["hero.png"], 1, :forever)
+      end
     end
   end
 

--- a/app/walking_sprite_example.rb
+++ b/app/walking_sprite_example.rb
@@ -28,8 +28,12 @@ class WalkingSpriteExample < MG::Scene
     add @hero
 
     on_touch_begin do |event|
+      @hero.flipped_horizontally = moved_left?(event.location)
       @hero.move_to(event.location, 1)
     end
   end
 
+  def moved_left?(new_location)
+    new_location.x < @hero.position.x
+  end
 end


### PR DESCRIPTION
* Flip sprite when walking the other direction.
* Calculate distance using pythagorean theorem, in order to calculate constant speed to move, regardless of distance.
* Fix walking animation so that the sprite stops animating when it reaches its destination.